### PR TITLE
Create gif endpoint to delete gif

### DIFF
--- a/api/v1/models/gif.sql
+++ b/api/v1/models/gif.sql
@@ -3,9 +3,6 @@ CREATE TABLE gifs (
   "title" VARCHAR(255),
   "imageUrl" VARCHAR(255) NOT NULL,
   "public_id" VARCHAR(255) NOT NULL,
-  "claps" INTEGER DEFAULT 0,
-  "flaggedInvalid" INTEGER DEFAULT 0,
   "createdOn" TIMESTAMP DEFAULT current_timestamp,
-  "updatedOn" TIMESTAMP DEFAULT current_timestamp,
   "userId" SERIAL REFERENCES users ("userId")
 );

--- a/api/v1/routes/gifRoutes.js
+++ b/api/v1/routes/gifRoutes.js
@@ -6,5 +6,6 @@ const auth = require('../middleware/authMiddleware');
 const gifController = require('../controllers/GifController');
 
 router.post('/', auth, gifController.createGif);
+router.delete('/:gifId', auth, gifController.deleteGif);
 
 module.exports = router;

--- a/api/v1/services/GifService.js
+++ b/api/v1/services/GifService.js
@@ -6,8 +6,29 @@ class GifService {
     try {
       const newGifQuery = 'INSERT INTO gifs ("title", "imageUrl", "public_id", "userId") VALUES($1, $2, $3, $4) RETURNING *';
       const values = [`${newGif.title}`, `${newGif.imageUrl}`, `${newGif.public_id}`, `${newGif.userId}`];
-      const result = await pool.query(newGifQuery, values);
-      return result;
+      const { rows } = await pool.query(newGifQuery, values);
+      return rows[0];
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  static async deleteGif(gifToDelete) {
+    try {
+      let deleted = [];
+      const { rows } = await pool.query('SELECT * from gifs WHERE "gifId" = $1', [gifToDelete.gifId]);
+      if (!rows) {
+        return 'Sorry, gif not found';
+      }
+      console.log(gifToDelete);
+      deleted = rows[0];
+      if (rows[0].userId === gifToDelete.userId) {
+        const newGifQuery = 'DELETE FROM gifs WHERE "gifId" = ($1)';
+        const values = [`${gifToDelete.gifId}`];
+        await pool.query(newGifQuery, values);
+        return deleted;
+      }
+      return rows[0];
     } catch (error) {
       throw error;
     }

--- a/api/v1/test/gif.spec.js
+++ b/api/v1/test/gif.spec.js
@@ -28,4 +28,25 @@ describe('On Teamwork API', () => {
       done();
     });
   });
+
+  describe('a DELETE request to "/gifs/:gifId"', () => {
+    it('should check if user is authenticated and owner of gif before deleting gif', (done) => {
+      chai.request(app)
+        .post('/api/v1/gifs/1')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .set({ Authorization: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTU3MzU2ODA5NSwiZXhwIjoxNTczNjU0NDk1fQ.0iGYd7Rh7wPiG24Kwtq_clG_82iIvOPlYIVgZJUZNKc' })
+        .field('title', 'my title')
+        .attach('gif', fs.readFileSync('./api/v1/test/images/gif1.gif'), 'gif1.gif')
+        .then((res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.data).to.include({
+            message: 'gif post successfully deleted'
+          });
+        })
+        .catch((err) => {
+          console.log(err.message);
+        });
+      done();
+    });
+  });
 });


### PR DESCRIPTION
## Related Issue
Fixes #22  

### What does this PR do?
Setup /gif/:gifId endpoint for users to delete their

### Description of Task to be completed?
Enable user to delete gif
Deletes user gif details from cloudinary and database

### How should this be manually tested?
Clone the repository, cd into project folder and run npm install
Run npm run dev-server
Open Postman
Open localhost:3000/api/v1/gif/:gifId and make DELETE request with gifId
Add token to header

### What are the relevant github project card note?
https://github.com/odinaka-joy/api_teamwork/projects/2#card-29261316